### PR TITLE
Edit hook script

### DIFF
--- a/resources/hooks/prepare-commit-msg
+++ b/resources/hooks/prepare-commit-msg
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Identifier, do not change if modifying:
-#DarkyenusTimeTrackerHookScript00001
+#DarkyenusTimeTrackerHookScript00002
 
 # Script (can be modified, but may be overwritten if new plugin version is installed):
 
@@ -48,8 +48,8 @@ then
 	        fi
         fi
 
-        printf "\n\nTook$TIME_MESSAGE" >> $1
-        echo "0" > ${DTT_TIME}
+        printf "\n\nTook$TIME_MESSAGE" >> "$1"
+        echo "0" > "$DTT_TIME"
         echo "Commit took$TIME_MESSAGE"
     else
         echo "Commit took no time, not recording"

--- a/src/com/darkyen/GitIntegration.java
+++ b/src/com/darkyen/GitIntegration.java
@@ -64,7 +64,7 @@ final class GitIntegration {
 
     private static final String PREPARE_COMMIT_MESSAGE_HOOK_NAME = "prepare-commit-msg";
     private static final String TIME_TRACKER_HOOK_IDENTIFIER = "#DarkyenusTimeTrackerHookScript";
-    private static final String TIME_TRACKER_HOOK_IDENTIFIER_VERSIONED = TIME_TRACKER_HOOK_IDENTIFIER+"00001";
+    private static final String TIME_TRACKER_HOOK_IDENTIFIER_VERSIONED = TIME_TRACKER_HOOK_IDENTIFIER+"00002";
 
     private static VirtualFile getHookDirectory(Project project) {
         final VirtualFile git = project.getBaseDir().findChild(".git");


### PR DESCRIPTION
Strings in quotes are better, because they are more stable to special characters like spaces and other characters. Also for some reason reset of commit time didn't work for me. Now it does.