### PR TITLE
Widget show only hours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /out/
 /*.jar
+.idea/

--- a/resources/hooks/prepare-commit-msg
+++ b/resources/hooks/prepare-commit-msg
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Identifier, do not change if modifying:
-#DarkyenusTimeTrackerHookScript00001
+#DarkyenusTimeTrackerHookScript00002
 
 # Script (can be modified, but may be overwritten if new plugin version is installed):
 
@@ -48,8 +48,8 @@ then
 	        fi
         fi
 
-        printf "\n\nTook$TIME_MESSAGE" >> $1
-        echo "0" > ${DTT_TIME}
+        printf "\n\nTook$TIME_MESSAGE" >> "$1"
+        echo "0" > "$DTT_TIME"
         echo "Commit took$TIME_MESSAGE"
     else
         echo "Commit took no time, not recording"

--- a/src/com/darkyen/GitIntegration.java
+++ b/src/com/darkyen/GitIntegration.java
@@ -64,7 +64,7 @@ final class GitIntegration {
 
     private static final String PREPARE_COMMIT_MESSAGE_HOOK_NAME = "prepare-commit-msg";
     private static final String TIME_TRACKER_HOOK_IDENTIFIER = "#DarkyenusTimeTrackerHookScript";
-    private static final String TIME_TRACKER_HOOK_IDENTIFIER_VERSIONED = TIME_TRACKER_HOOK_IDENTIFIER+"00001";
+    private static final String TIME_TRACKER_HOOK_IDENTIFIER_VERSIONED = TIME_TRACKER_HOOK_IDENTIFIER+"00002";
 
     private static VirtualFile getHookDirectory(Project project) {
         final VirtualFile git = project.getBaseDir().findChild(".git");

--- a/src/com/darkyen/TimeTrackerState.java
+++ b/src/com/darkyen/TimeTrackerState.java
@@ -10,6 +10,7 @@ public final class TimeTrackerState {
     public boolean autoStart = true;
     public long idleThresholdMs = 2 * 60 * 1000;
     public boolean gitIntegration = false;
+    public boolean showOnlyHours = false;
     public boolean pauseOtherTrackerInstances = true;
 
     /** Bit field recording which features did we suggest user to enable. */


### PR DESCRIPTION
If turned on, IDE widget shows time only in hours, no days or minutes - useful when working on paid projects. Also, since you never work 24hours straight, it gives a better idea about time spent