### PR TITLE
Change shebang to work on NixOS

### DIFF
--- a/resources/hooks/prepare-commit-msg
+++ b/resources/hooks/prepare-commit-msg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Identifier, do not change if modifying:
 #DarkyenusTimeTrackerHookScript00006


### PR DESCRIPTION
See this related issue https://github.com/plone/plone.recipe.codeanalysis/issues/55

I'm also on NixOS, and editing that line prevented a wierd and obscure "No such file or directory" error.